### PR TITLE
管理者ユーザに対するチャットルームを非表示にできないように修正

### DIFF
--- a/app/views/rooms/index.html.erb
+++ b/app/views/rooms/index.html.erb
@@ -28,7 +28,9 @@
             <p class="unread-message-count"><%= "未読のメッセージが#{unread_count}件あります" %></p>
           <% end %>
           <div class="comment-edit">
-            <%= link_to "非表示", "/hidden_rooms?room_id=#{room_id}", method: "post" %>
+            <% unless user.admin? %>
+              <%= link_to "非表示", "/hidden_rooms?room_id=#{room_id}", method: "post" %>
+            <% end %>
           </div>
           
         </div>


### PR DESCRIPTION
【修正理由】
・管理者ユーザはセキュリティ上、ユーザ一覧に表示されないようにしているため、初回作成されたチャットルームを一度非表示にしてしまうと、戻すことができない。(/rooms/:id?user_id=xxx のアクセスで復活可能だが、一般ユーザでは気づけない)

・管理者からのメッセージはシステム利用上の注意やメンテナンス情報の連絡手段として重宝するため、非表示にされてしまうと不便。

【備考】
・管理者ユーザとのチャットルームが非表示にできない不便さは許容する。
